### PR TITLE
Move logback-test to test resources, add logs to gitignore and change…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 resouces/data.cql
 resouces/clear.cql
 *.iml
+logs

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
Move logback-test to test resources, add logs to gitignore and change test log level from DEBUG to INFO to avoid build error bacause of log file size restrictions.